### PR TITLE
Retrofit the Yk JIT into the Lua interpreter.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,8 +2,55 @@
 
 set -e
 
+# First build without the JIT and check the tests still work.
 make -j `nproc`
-
-# https://www.lua.org/tests/
 cd tests
 ../src/lua -e"_U=true" all.lua
+cd ..
+make clean
+
+# Now test again with the JIT enabled.
+#
+# First we build ykllvm.
+git clone --depth 1 https://github.com/ykjit/ykllvm
+cd ykllvm
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=`pwd`/../inst \
+    -DLLVM_INSTALL_UTILS=On \
+    -DCMAKE_BUILD_TYPE=release \
+    -DLLVM_ENABLE_ASSERTIONS=On \
+    -DLLVM_ENABLE_PROJECTS="lld;clang" \
+	-GNinja \
+    ../llvm
+cmake --build .
+cmake --install .
+export PATH=`pwd`/../inst/bin:${PATH}
+cd ../..
+
+# Then we build Yk.
+export CARGO_HOME="`pwd`/.cargo"
+export RUSTUP_HOME="`pwd`/.rustup"
+export RUSTUP_INIT_SKIP_PATH_CHECK="yes"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+sh rustup.sh --default-host x86_64-unknown-linux-gnu \
+    --default-toolchain nightly \
+    --no-modify-path \
+    --profile minimal \
+    -y
+export PATH=`pwd`/.cargo/bin/:$PATH
+
+git clone --depth 1 https://github.com/softdevteam/yk
+cd yk && cargo build
+cd ..
+
+make -j `nproc` YK_DIR=`pwd`/yk YK_DIR=`pwd`/yk
+cd tests
+# YKFIXME: The JIT can't yet run the test suite, but the following commented
+# commands are what we are aiming at having work.
+#
+# YKFIXME: The tests are very short-lived and will probably need to be made to
+# run longer to allow for JIT compilation to complete.
+#
+#../src/lua -e"_U=true" all.lua
+#YKD_SERIALISE_COMPILATION=1 ../src/lua -e"_U=true" all.lua

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Yk-enabled Lua
+
+This is the reference Lua interpreter with the Yk JIT retrofitted.
+
+This is experimental!
+
+## Building
+
+GNU make is required.
+
+Run:
+```
+make YK_DIR=<path-to-compiled-yk>
+```

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,38 @@ MYLDFLAGS=
 MYLIBS=
 MYOBJS=
 
+# Flags for enabling the Yk JIT.
+#
+# See langtest_c.rs from the `yk` repo for an explanation of the flags.
+YK_LIBDIR=	$(YK_DIR)/target/debug
+YK_CFLAGS=	-DUSE_YK \
+		-DLUA_USE_JUMPTABLE=0 \
+		-flto \
+		-I$(YK_DIR)/ykcapi
+YK_LDFLAGS=	-fuse-ld=lld \
+		-Wl,--mllvm=--embed-bitcode-final \
+		-Wl,--mllvm=--disable-branch-fold \
+		-Wl,--mllvm=--disable-block-placement \
+		-Wl,--mllvm=--disable-early-taildup \
+		-Wl,--mllvm=--disable-tail-duplicate \
+		-Wl,--mllvm=--yk-disable-tail-call-codegen \
+		-Wl,--mllvm=--yk-no-fallthrough \
+		-Wl,--mllvm=--yk-patch-control-point \
+		-Wl,--mllvm=--yk-block-disambiguate \
+		-Wl,--lto-basic-block-sections=labels \
+		-Wl,--export-dynamic \
+		-L$(YK_LIBDIR) \
+		-Wl,-rpath=$(YK_LIBDIR)
+YK_LIBS=	-lykcapi
+
+# If $(YK_DIR) is set then build with Yk JIT support.
+ifneq ($(strip $(YK_DIR)),)
+CC=		clang
+MYCFLAGS +=	$(YK_CFLAGS)
+MYLDFLAGS +=	$(YK_LDFLAGS)
+MYLIBS +=	$(YK_LIBS)
+endif
+
 # Special flags for compiler modules; -Os reduces code size.
 CMCFLAGS= 
 

--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -11,6 +11,7 @@
 
 
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "lua.h"
 
@@ -20,6 +21,7 @@
 #include "lgc.h"
 #include "lmem.h"
 #include "lobject.h"
+#include "lopcodes.h"
 #include "lstate.h"
 
 
@@ -245,6 +247,9 @@ Proto *luaF_newproto (lua_State *L) {
   f->p = NULL;
   f->sizep = 0;
   f->code = NULL;
+#ifdef USE_YK
+  f->yklocs = NULL;
+#endif
   f->sizecode = 0;
   f->lineinfo = NULL;
   f->sizelineinfo = 0;
@@ -265,6 +270,12 @@ Proto *luaF_newproto (lua_State *L) {
 
 
 void luaF_freeproto (lua_State *L, Proto *f) {
+#ifdef USE_YK
+  for (int i = 0; i < f->sizecode; i++)
+    if (isLoopStart(f->code[i]))
+        yk_location_drop(f->yklocs[i]);
+  free(f->yklocs);
+#endif
   luaM_freearray(L, f->code, f->sizecode);
   luaM_freearray(L, f->p, f->sizep);
   luaM_freearray(L, f->k, f->sizek);

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -10,6 +10,9 @@
 
 
 #include <stdarg.h>
+#ifdef USE_YK
+#include <yk.h>
+#endif
 
 
 #include "llimits.h"
@@ -552,6 +555,9 @@ typedef struct Proto {
   int lastlinedefined;  /* debug information  */
   TValue *k;  /* constants used by the function */
   Instruction *code;  /* opcodes */
+#ifdef USE_YK
+  YkLocation *yklocs; /* JIT locations */
+#endif
   struct Proto **p;  /* functions defined inside the function */
   Upvaldesc *upvalues;  /* upvalue information */
   ls_byte *lineinfo;  /* information about source lines (debug information) */

--- a/src/lopcodes.c
+++ b/src/lopcodes.c
@@ -101,4 +101,3 @@ LUAI_DDEF const lu_byte luaP_opmodes[NUM_OPCODES] = {
  ,opmode(0, 0, 1, 0, 1, iABC)		/* OP_VARARGPREP */
  ,opmode(0, 0, 0, 0, 0, iAx)		/* OP_EXTRAARG */
 };
-

--- a/src/lopcodes.h
+++ b/src/lopcodes.h
@@ -380,6 +380,15 @@ OP_EXTRAARG/*	Ax	extra (larger) argument for previous opcode	*/
 
 LUAI_DDEC(const lu_byte luaP_opmodes[NUM_OPCODES];)
 
+#ifdef USE_YK
+/*
+ * Is the instruction `i` the start of a loop?
+ *
+ * YKFIXME: Figure out what other opcodes can be loop starts.
+ */
+#define isLoopStart(i) (GET_OPCODE(i) == OP_FORLOOP)
+#endif
+
 #define getOpMode(m)	(cast(enum OpMode, luaP_opmodes[m] & 7))
 #define testAMode(m)	(luaP_opmodes[m] & (1 << 3))
 #define testTMode(m)	(luaP_opmodes[m] & (1 << 4))

--- a/src/lvm.h
+++ b/src/lvm.h
@@ -125,7 +125,14 @@ LUAI_FUNC void luaV_finishget (lua_State *L, const TValue *t, TValue *key,
 LUAI_FUNC void luaV_finishset (lua_State *L, const TValue *t, TValue *key,
                                TValue *val, const TValue *slot);
 LUAI_FUNC void luaV_finishOp (lua_State *L);
-LUAI_FUNC void luaV_execute (lua_State *L, CallInfo *ci);
+/*
+ * YKFIXME: We had to remove LUAI_FUNC from `luaV_execute()` to prevent clang
+ * from optimising the return value out of its signature.
+ *
+ * This is part of a temporary workaround for:
+ * https://github.com/ykjit/yk/issues/537
+ */
+uint32_t luaV_execute (lua_State *L, CallInfo *ci);
 LUAI_FUNC void luaV_concat (lua_State *L, int total);
 LUAI_FUNC lua_Integer luaV_idiv (lua_State *L, lua_Integer x, lua_Integer y);
 LUAI_FUNC lua_Integer luaV_mod (lua_State *L, lua_Integer x, lua_Integer y);


### PR DESCRIPTION
Obviously nothing really works yet, but this is a good starting point.

The JIT can be conditionally compiled in if `YK_DIR` is set (e.g. `make
YK_DIR=~/yk`). Sadly I had to make a portable Makefile into a GNU
Makefile for that to work though. I don't think it matters too much.

Currently we only make JIT locations for regular `for` loops.

The test suite currently seg faults when using the JIT, so that's
commented in CI for now.

This simple program makes it to stop-gapping and then fails a
stackmap-related assertion:

```
for i = 0, 100 do
    print("hello!")
end
```

It's a start.