### PR TITLE
Remove the need to set YK_DIR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ GNU make is required.
 
 Run:
 ```
-make YK_DIR=<path-to-compiled-yk>
+export PATH=/path/to/yk/ykcapi/scripts:${PATH}
+export YK_BUILD_TYPE=<debug|release>
+make
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,9 +37,9 @@ YK_CFLAGS=	-DUSE_YK \
 YK_LDFLAGS=	`yk-config ${YK_BUILD_TYPE} --ldflags`
 YK_LIBS=	`yk-config ${YK_BUILD_TYPE} --libs`
 
-# If $(YK_DIR) is set then build with Yk JIT support.
+# If $(YK_BUILD_TYPE) is set then build with Yk JIT support.
 # The clang in $PATH must be the one from ykllvm.
-ifneq ($(strip $(YK_DIR)),)
+ifneq ($(strip $(YK_BUILD_TYPE)),)
 CC=		clang
 MYCFLAGS +=	$(YK_CFLAGS)
 MYLDFLAGS +=	$(YK_LDFLAGS)


### PR DESCRIPTION
Before you needed to set (and it wasn't well-documented):
 - `PATH` to include `yk-config`.
 - `YK_BUILD_TYPE` to `debug` or `release`.
 - `YK_DIR` to the `yk` clone.

This change removes the need for `YK_DIR` (and gives an error message if `yk-config` can't be found).