### PR TITLE
Only construct one MT instance per Lua interpreter instance.

### DIFF
--- a/src/lstate.c
+++ b/src/lstate.c
@@ -277,6 +277,9 @@ static void close_state (lua_State *L) {
     luai_userstateclose(L);
   }
   luaM_freearray(L, G(L)->strt.hash, G(L)->strt.size);
+#if USE_YK
+  yk_mt_drop(G(L)->yk_mt);
+#endif
   freestack(L);
   lua_assert(gettotalbytes(g) == sizeof(LG));
   (*g->frealloc)(g->ud, fromstate(L), sizeof(LG), 0);  /* free main block */
@@ -399,6 +402,10 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
   setgcparam(g->genmajormul, LUAI_GENMAJORMUL);
   g->genminormul = LUAI_GENMINORMUL;
   for (i=0; i < LUA_NUMTAGS; i++) g->mt[i] = NULL;
+#ifdef USE_YK
+  g->yk_mt = yk_mt_new(NULL);
+  yk_mt_hot_threshold_set(g->yk_mt, 5); /* YKFIXME: allow changing threshold */
+#endif
   if (luaD_rawrunprotected(L, f_luaopen, NULL) != LUA_OK) {
     /* memory allocation error: free partial state */
     close_state(L);

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -13,6 +13,10 @@
 #include "ltm.h"
 #include "lzio.h"
 
+#ifdef USE_YK
+#  include <yk.h>
+#endif
+
 
 /*
 ** Some notes about garbage-collected objects: All objects in Lua must
@@ -295,6 +299,9 @@ typedef struct global_State {
   TString *strcache[STRCACHE_N][STRCACHE_M];  /* cache for strings in API */
   lua_WarnFunction warnf;  /* warning function */
   void *ud_warn;         /* auxiliary data to 'warnf' */
+#ifdef USE_YK
+  YkMT *yk_mt;
+#endif
 } global_State;
 
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1185,10 +1185,6 @@ uint32_t luaV_execute (lua_State *L, CallInfo *ci) {
     ci->u.l.trap = 1;  /* assume trap is on, for now */
   }
   base = ci->func + 1;
-#ifdef USE_YK
-  YkMT *mt = yk_mt_new(NULL);
-  yk_mt_hot_threshold_set(mt, 5); /* YKFIXME: allow changing threshold */
-#endif
   /* main loop of interpreter */
   for (;;) {
     Instruction i;  /* instruction being executed */
@@ -1199,7 +1195,7 @@ uint32_t luaV_execute (lua_State *L, CallInfo *ci) {
     StkId ra;  /* instruction's A register */
     vmfetch();
 #ifdef USE_YK
-    yk_mt_control_point(mt, ykloc);
+    yk_mt_control_point(G(L)->yk_mt, ykloc);
 #endif
     #if 0
       /* low-level line tracing for debugging Lua */
@@ -1870,9 +1866,6 @@ uint32_t luaV_execute (lua_State *L, CallInfo *ci) {
       }
     }
   }
-#if USE_YK
-  yk_mt_drop(mt);
-#endif
   return 0;
 }
 


### PR DESCRIPTION
Previously we constructed a new MT instance for every Lua function call: this commit moves that to what appears to be the global "initialise/deinitialise a Lua interpreter" functions. I'm not entirely sure if I've got the `yk_mt_drop` in exactly the right part of the `close` function, but it's certainly nearer to the right place than before.