### PR TITLE
Use ykllvm's `ar` and `ranlib`.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,6 +40,8 @@ YK_LIBS=	`yk-config ${YK_BUILD_TYPE} --libs`
 # If $(YK_BUILD_TYPE) is set then build with Yk JIT support.
 ifneq ($(strip $(YK_BUILD_TYPE)),)
 CC=		`yk-config ${YK_BUILD_TYPE} --cc`
+AR=		`yk-config ${YK_BUILD_TYPE} --ar` rcu
+RANLIB=		`yk-config ${YK_BUILD_TYPE} --ranlib`
 MYCFLAGS +=	$(YK_CFLAGS)
 MYLDFLAGS +=	$(YK_LDFLAGS)
 MYLIBS +=	$(YK_LIBS)
@@ -64,10 +66,7 @@ LUAC_T=	luac
 LUAC_O=	luac.o
 
 ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
-# Yk: We don't build liblua.a because we don't need it and it doesn't LTO
-# properly anyway (`ar` calls the system clang's LTO plugin instead of
-# ykllvm's).
-ALL_T= $(LUA_T) $(LUAC_T) # $(LUA_A)
+ALL_T= $(LUA_T) $(LUAC_T) $(LUA_A)
 ALL_A= $(LUA_A)
 
 # Targets start here.


### PR DESCRIPTION
**Requires https://github.com/ykjit/yk/pull/789**

Before we had a hack which tried to disable building the lua interpreter as a static library in an attempt to silence:

```
ar: `u' modifier ignored since `D' is the default (see `U')
bfd plugin: LLVM gold plugin has failed to create LTO module: Not an int attribute (Producer: 'LLVM16.0.0git' Reader: 'LLVM 13.0.1')
bfd plugin: LLVM gold plugin has failed to create LTO module: Not an int attribute (Producer: 'LLVM16.0.0git' Reader: 'LLVM 13.0.1')
bfd plugin: LLVM gold plugin has failed to create LTO module: Invalid record
```

Not only did it not disable building `liblua.a` (it gets pulled in later in the dependency chain anway), it also didn't silence the warning.

We can't disable building liblua.a, because all other versions of the interpreter (e.g. static binary, and shared object) are built from `liblua.a`.

The warning is telling us that the system `ar` built LTO artifacts for an earlier version of LLVM bytecode. We can silence it by using ykllvm's `ar` and `ranlib`.

In doing so, we likely have more IR availbable to JIT.

Fixes #20