### PR TITLE
Add function undump locations recovery

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -43,15 +43,11 @@ cd tests
 #
 # Until we can run `all.lua` reliably, we just run the tests that we know to
 # run within reasonable time).
-#
-# Note that the following tests have been known to non-deterministically crash
-# (fairly rarely) and should be tested with `try_repeat` before being
-# re-enabled: literals, constructs, goto.
 LUA=../src/lua
 for serialise in 0 1; do
-    for test in api bwcoercion closure code coroutine events \
-        gengc pm tpack tracegc utf8 vararg; do
+    for test in api bwcoercion closure code coroutine constructs events \
+        gengc pm tpack tracegc utf8 vararg goto literals; do
         echo "### YKD_SERIALISE_COMPILATION=$serialise $test.lua ###"
-        YKD_SERIALISE_COMPILATION=$serialise ${LUA} ${test}.lua
+        YKD_SERIALISE_COMPILATION=$serialise ${LUA} -e"_U=true" ${test}.lua
     done
 done

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the reference Lua interpreter with the Yk JIT retrofitted.
 
 This is experimental!
 
-## Building
+## Build
 
 GNU make is required.
 
@@ -15,10 +15,26 @@ export YK_BUILD_TYPE=<debug|release>
 make
 ```
 
-## Runinng
+## Run
 
 ```shell
 ./src/lua -e "print('Hello World')" # execute program passed in as string
 ./src/lua ./tests/utf8.lua # execute lua program file 
 ./src/luac ./tests/utf8.lua -o ./utf8.out # translates lua programs into Lua bytecode
+```
+
+## Test
+
+> Make sure to build the project first.
+
+```shell
+cd tests # navigate to tests directory
+../src/lua -e"_U=true" db.lua # run single file
+../src/lua -e"_U=true" all.lua # run complete test suite (Currently failing)
+```
+
+### Docker
+
+```shell
+run_docker_ci_job # local path to https://github.com/softdevteam/buildbot_config/blob/master/bin/run_docker_ci_job
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ CMCFLAGS=
 PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
 
 LUA_A=	liblua.a
-CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
+CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o lyk.o
 LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
 BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
 
@@ -240,5 +240,5 @@ lvm.o: lvm.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h \
  ltable.h lvm.h ljumptab.h
 lzio.o: lzio.c lprefix.h lua.h luaconf.h llimits.h lmem.h lstate.h \
  lobject.h ltm.h lzio.h
-
+lyk.o: lyk.h lyk.c
 # (end of Makefile)

--- a/src/lcode.c
+++ b/src/lcode.c
@@ -8,7 +8,7 @@
 #define LUA_CORE
 
 #ifdef USE_YK
-#define _DEFAULT_SOURCE /* for reallocarray() */
+#import "lyk.h"
 #endif
 
 #include "lprefix.h"
@@ -391,15 +391,7 @@ int luaK_code (FuncState *fs, Instruction i) {
                   MAX_INT, "opcodes");
   f->code[fs->pc++] = i;
 #ifdef USE_YK
-  // YKOPT: Reallocating for every instruction is inefficient.
-  if ((f->yklocs = reallocarray(f->yklocs, fs->pc,
-    sizeof(YkLocation))) == NULL)
-  {
-      luaG_runerror(fs->ls->L, "failed to allocate JIT location");
-  }
-  if (isLoopStart(i))
-      f->yklocs[idx] = yk_location_new();
-  /* `else f->yklocs[idx]` is undefined */
+  yk_set_location(f, i, idx, fs->pc);
 #endif
   savelineinfo(fs, f, fs->ls->lastline);
   return idx;  /* index of new instruction */

--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -24,6 +24,9 @@
 #include "lopcodes.h"
 #include "lstate.h"
 
+#ifdef USE_YK  
+#include "lyk.h"
+#endif
 
 
 CClosure *luaF_newCclosure (lua_State *L, int nupvals) {
@@ -268,13 +271,9 @@ Proto *luaF_newproto (lua_State *L) {
   return f;
 }
 
-
 void luaF_freeproto (lua_State *L, Proto *f) {
 #ifdef USE_YK
-  for (int i = 0; i < f->sizecode; i++)
-    if (isLoopStart(f->code[i]))
-        yk_location_drop(f->yklocs[i]);
-  free(f->yklocs);
+  yk_free_locactions(f);
 #endif
   luaM_freearray(L, f->code, f->sizecode);
   luaM_freearray(L, f->p, f->sizep);

--- a/src/lopcodes.h
+++ b/src/lopcodes.h
@@ -380,16 +380,6 @@ OP_EXTRAARG/*	Ax	extra (larger) argument for previous opcode	*/
 
 LUAI_DDEC(const lu_byte luaP_opmodes[NUM_OPCODES];)
 
-#ifdef USE_YK
-/*
- * Is the instruction `i` the start of a loop?
- *
- * YKFIXME: Numeric and Generic loops can be identified by OP_FORLOOP and OP_TFORLOOP opcodes. 
- * Other loops like while and repeat-until are harder to identify since they are based on OP_JMP instruction.
- */
-#define isLoopStart(i) (GET_OPCODE(i) == OP_FORLOOP || GET_OPCODE(i) == OP_TFORLOOP)
-#endif
-
 #define getOpMode(m)	(cast(enum OpMode, luaP_opmodes[m] & 7))
 #define testAMode(m)	(luaP_opmodes[m] & (1 << 3))
 #define testTMode(m)	(luaP_opmodes[m] & (1 << 4))

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -14,7 +14,7 @@
 #include "lzio.h"
 
 #ifdef USE_YK
-#  include <yk.h>
+#include <yk.h>
 #endif
 
 

--- a/src/lundump.c
+++ b/src/lundump.c
@@ -29,6 +29,9 @@
 #define luai_verifycode(L,f)  /* empty */
 #endif
 
+#ifdef USE_YK
+#include "lyk.h"
+#endif
 
 typedef struct {
   lua_State *L;
@@ -267,6 +270,9 @@ static void loadFunction (LoadState *S, Proto *f, TString *psource) {
   loadUpvalues(S, f);
   loadProtos(S, f);
   loadDebug(S, f);
+  #ifdef USE_YK
+  yk_set_locations(f);
+  #endif
 }
 
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1141,15 +1141,7 @@ void luaV_finishOp (lua_State *L) {
  * it, otherwise `ykloc` is set `NULL`.
  */
 #ifdef USE_YK
-#define lookup_ykloc() { \
-    lua_assert(isLua(ci)); \
-    Proto *p = ci_func(ci)->p; \
-    lua_assert(p->code <= pc && pc <= p->code + p->sizecode); \
-    if (isLoopStart(*pc)) \
-        ykloc = &p->yklocs[pc - p->code]; \
-    else \
-        ykloc = NULL; \
-}
+#include "lyk.h"
 #endif
 
 #define vmdispatch(o)	switch(o)
@@ -1186,8 +1178,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
   for (;;) {
     Instruction i;  /* instruction being executed */
 #ifdef USE_YK
-    YkLocation *ykloc;
-    lookup_ykloc();
+    YkLocation *ykloc = yk_lookup_ykloc(ci, pc);
 #endif
     StkId ra;  /* instruction's A register */
     vmfetch();

--- a/src/lyk.c
+++ b/src/lyk.c
@@ -1,0 +1,77 @@
+#ifdef USE_YK
+
+#include "lyk.h"
+#include "lobject.h"
+#include "lopcodes.h"
+#include "ldebug.h"
+#include <stdlib.h>
+#include <yk.h>
+
+#define _DEFAULT_SOURCE /* for reallocarray() */
+
+/*
+ *  Function prototypes in Lua are loaded through two methods:
+ *    1.  They are loaded from text source via the `luaY_parser`.
+ *    2.  They can also be loaded from binary representation using `luaU_undump`, where
+ *        prototypes are previously dumped and saved.
+ * 
+ *  Yk tracing locations are allocated using both of these methods 
+ *  using `yk_set_location` and `yk_set_locations` respectively.
+*/
+
+/*
+ *  Is the instruction `i` the start of a loop?
+ *
+ *  YKFIXME: Numeric and Generic loops can be identified by `OP_FORLOOP` and `OP_TFORLOOP` opcodes. 
+ *  Other loops like while and repeat-until are harder to identify since they are based on 
+ *  `OP_JMP` instruction.
+ */
+int is_loop_start(Instruction i) {
+  return (GET_OPCODE(i) == OP_FORLOOP || GET_OPCODE(i) == OP_TFORLOOP);
+}
+
+inline YkLocation *yk_lookup_ykloc(CallInfo *ci, Instruction *pc){
+  YkLocation *ykloc = NULL;
+  lua_assert(isLua(ci));
+  Proto *p = ci_func(ci)->p;
+  lua_assert(p->code <= pc && pc <= p->code + p->sizecode);
+  if (is_loop_start(*pc)) {
+    ykloc = &p->yklocs[pc - p->code];
+  }
+  return ykloc;
+}
+
+inline void yk_set_location(Proto *f, Instruction i, int idx, int pc) {
+  // YKOPT: Reallocating for every instruction is inefficient.
+  f->yklocs = reallocarray(f->yklocs, pc, sizeof(YkLocation));
+  lua_assert(f->yklocs != NULL && "Expected yklocs to be defined!");
+  if (is_loop_start(i))
+  {
+    f->yklocs[idx] = yk_location_new();
+  }
+}
+
+inline void yk_set_locations(Proto *f) {
+  f->yklocs = calloc(f->sizecode, sizeof(YkLocation));
+  lua_assert(f->yklocs != NULL && "Expected yklocs to be defined!");
+  for (int i = 0; i < f->sizecode; i++){
+     if (is_loop_start(i)){
+      f->yklocs[i] = yk_location_new();
+    }
+  }
+}
+
+void free_loc(Proto *f, Instruction i, int idx) {
+  if (is_loop_start(i)) {
+    yk_location_drop(f->yklocs[idx]);
+  }
+}
+
+inline void yk_free_locactions(Proto *f) {
+  for (int i = 0; i < f->sizecode; i++) {
+    free_loc(f, f->code[i], i);
+  }
+  free(f->yklocs);
+  f->yklocs = NULL;
+}
+#endif // USE_YK

--- a/src/lyk.h
+++ b/src/lyk.h
@@ -1,0 +1,16 @@
+#ifndef __LYK_H
+#define __LYK_H
+
+#include "lobject.h"
+#include "lopcodes.h"
+#include "lstate.h"
+
+void yk_set_location(Proto *f, Instruction i, int idx, int pc);
+
+void yk_set_locations(Proto *f);
+
+void yk_free_locactions(Proto *f);
+
+YkLocation* yk_lookup_ykloc(CallInfo *ci, Instruction *pc);
+
+#endif // __LYK_H


### PR DESCRIPTION
Solves https://github.com/ykjit/yklua/issues/32

+ Added function prototype location reconstruction as part of function
undump process.
+ Moved yk functionality to lyk.h and lyk.c.

### Note:
We still get errors such as: 

```shell
yk-fork/ykllvm/llvm/lib/IR/Value.cpp:1101: void llvm::ValueHandleBase::RemoveFromUseList(): Assertion `*PrevPtr == this && "List invariant broken"' failed
...
yk-fork/ykllvm/llvm/lib/IR/Value.cpp:1061: void llvm::ValueHandleBase::AddToUseList(): Assertion `Entry && "Value doesn't have any handles?"' failed
...
yk-fork/ykllvm/llvm/lib/IR/Value.cpp:285: llvm::ValueName* llvm::Value::getValueName() const: Assertion `I != Ctx.pImpl->ValueNames.end() && "No name entry found!"' failed.
```
when we run `../src/lua -e"_U=true" all.lua`.
