### PR TITLE
Add function loading error handling

### DIFF
--- a/src/lundump.c
+++ b/src/lundump.c
@@ -266,13 +266,13 @@ static void loadFunction (LoadState *S, Proto *f, TString *psource) {
   f->is_vararg = loadByte(S);
   f->maxstacksize = loadByte(S);
   loadCode(S, f);
+  #ifdef USE_YK
+  yk_set_locations(f);
+  #endif
   loadConstants(S, f);
   loadUpvalues(S, f);
   loadProtos(S, f);
   loadDebug(S, f);
-  #ifdef USE_YK
-  yk_set_locations(f);
-  #endif
 }
 
 

--- a/src/lyk.c
+++ b/src/lyk.c
@@ -68,10 +68,15 @@ void free_loc(Proto *f, Instruction i, int idx) {
 }
 
 inline void yk_free_locactions(Proto *f) {
-  for (int i = 0; i < f->sizecode; i++) {
-    free_loc(f, f->code[i], i);
+  // YK locations are initialised as close as possible to the function loading, 
+  // However, this load can fail before we initialise `yklocs`.
+  // This NULL check is a workaround for that.
+  if (f->yklocs != NULL) {
+    for (int i = 0; i < f->sizecode; i++) {
+      free_loc(f, f->code[i], i);
+    }
+    free(f->yklocs);
+    f->yklocs = NULL;
   }
-  free(f->yklocs);
-  f->yklocs = NULL;
 }
 #endif // USE_YK


### PR DESCRIPTION
Add a null check to handle uninitialized locations in functions that fail to load.
Set the initialisation of yklocations to be closer to the function code initialisation.

Related (not fixing) to https://github.com/ykjit/yklua/issues/43