### PR TITLE
Add serialised test - sort.lua

### DIFF
--- a/src/lcode.c
+++ b/src/lcode.c
@@ -391,7 +391,7 @@ int luaK_code (FuncState *fs, Instruction i) {
                   MAX_INT, "opcodes");
   f->code[fs->pc++] = i;
 #ifdef USE_YK
-  yk_ok_instruction_loaded(f, i, idx);
+  yk_on_instruction_loaded(f, i, idx);
 #endif
   savelineinfo(fs, f, fs->ls->lastline);
   return idx;  /* index of new instruction */

--- a/src/lyk.c
+++ b/src/lyk.c
@@ -90,7 +90,7 @@ void set_location(Proto *f, int i) {
   #endif // LYK_DEBUG
 }
 
-inline void yk_ok_instruction_loaded(Proto *f, Instruction i, int idx) {
+inline void yk_on_instruction_loaded(Proto *f, Instruction i, int idx) {
   // YKOPT: Reallocating for every instruction is inefficient.
   YkLocation **new_locations = calloc(f->sizecode, sizeof(YkLocation *));
   lua_assert(new_locations != NULL && "Expected yklocs to be defined!");

--- a/src/lyk.h
+++ b/src/lyk.h
@@ -7,7 +7,7 @@
 
 void yk_on_newproto(Proto *f);
 
-void yk_ok_instruction_loaded(Proto *f, Instruction i, int idx);
+void yk_on_instruction_loaded(Proto *f, Instruction i, int idx);
 
 void yk_on_proto_loaded(Proto *f);
 

--- a/test.sh
+++ b/test.sh
@@ -15,15 +15,21 @@ cd tests
 #
 # Until we can run `all.lua` reliably, we just run the tests that we know to
 # run within reasonable time).
+#
+# By default, when we run all.lua test suite, it runs underlying tests with a non-yk lua interpreter.
 
 LUA=../src/lua
 
+NON_SERIALISED="api bwcoercion closure code events gengc pm tpack tracegc vararg goto cstack locals"
+
 # Non-serialised compilation tests
-# YKFIXME: The following tests are known to work with non-serialised JIT
-for test in api bwcoercion closure code events \
-    gengc pm tpack tracegc vararg goto cstack locals; do
+# YKFIXME: The following tests are known to work only with non-serialised JIT
+for test in ${NON_SERIALISED}; do
     YKD_SERIALISE_COMPILATION=0 ${LUA} -e"_U=true" ${test}.lua
 done
 
-# Serialised compilation tests
-YKD_SERIALISE_COMPILATION=1 ${LUA} -e"_U=true" all.lua
+# YKFIXME: The following tests are known to work with serialised JIT
+serialised="${NON_SERIALISED} sort"
+for test in $serialised; do
+    YKD_SERIALISE_COMPILATION=1 ${LUA} -e"_U=true" ${test}.lua
+done


### PR DESCRIPTION
Related https://github.com/ykjit/yklua/issues/46
Related https://github.com/ykjit/yk/pull/830

+ Enabled sort.lua with serialised jit

Resilianse test:
```shell
YKD_SERIALISE_COMPILATION=1 try_repeat 1000 ../src/lua -e"_U=true" sort.lua
```