### PR TITLE
Add files.lua test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -23,6 +23,6 @@ for serialise in 0 1; do
                 gengc pm tpack tracegc vararg goto \
                 cstack locals literals files; do
         echo "### YKD_SERIALISE_COMPILATION=$serialise $test.lua ###"
-        YKD_SERIALISE_COMPILATION=$serialise ${LUA} ${test}.lua
+        YKD_SERIALISE_COMPILATION=$serialise ${LUA} -e"_U=true" ${test}.lua
     done
 done

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ LUA=../src/lua
 for serialise in 0 1; do
     for test in api bwcoercion closure code events \
                 gengc pm tpack tracegc vararg goto \
-                cstack locals literals; do
+                cstack locals literals files; do
         echo "### YKD_SERIALISE_COMPILATION=$serialise $test.lua ###"
         YKD_SERIALISE_COMPILATION=$serialise ${LUA} ${test}.lua
     done


### PR DESCRIPTION
* Add files.lua test to test.sh script.

README table has `files.lua` status as `Working`, but it was missing from test.sh script.
No filed issues were found for `files.lua`.

Resiliency tests:
```shell
YKD_SERIALISE_COMPILATION=0 try_repeat -v 300 ../src/lua -e"_U=true" files.lua 
YKD_SERIALISE_COMPILATION=1 try_repeat -v 300 ../src/lua -e"_U=true" files.lua
```
(300 cause serial compilation files.lua takes long time to run)