### PR TITLE
Set serialisation off for non-serialised compilation tests.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -e
 cd tests
 
 # YKFIXME: The YK JIT can't yet run the test suite with non-serialised compilation (YKD_SERIALISE_COMPILATION=0).
-# YKD_SERIALISE_COMPILATION=1 ../src/lua -e"_U=true" all.lua
+# YKD_SERIALISE_COMPILATION=0 ../src/lua -e"_U=true" all.lua
 
 # Running tests with a serialised compilation
 YKD_SERIALISE_COMPILATION=1 ../src/lua -e"_U=true" all.lua


### PR DESCRIPTION
Tiny change, set YKD_SERIALISE_COMPILATION=0 for non-serialised compilation tests.