### PR TITLE
Unbreak CI.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -49,7 +49,8 @@ YKB_YKLLVM_BUILD_ARGS="define:CMAKE_C_COMPILER=/usr/bin/clang,define:CMAKE_CXX_C
 export PATH=`pwd`/bin:${PATH}
 cd ..
 
-YK_BUILD_TYPE=debug make -j `nproc`
+YKD_NEW_CODEGEN=1 YK_BUILD_TYPE=debug make -j `nproc`
 
 # Run the test suite
-cd tests && YKD_SERIALISE_COMPILATION=1 ../src/lua -e"_U=true" all.lua
+cd tests && YKD_NEW_CODEGEN=1 YKD_SERIALISE_COMPILATION=1 \
+    ../src/lua -e"_U=true" all.lua


### PR DESCRIPTION
I was investigating why nightly builds fail. In fact CI is broken for this repo.

We have to set YKD_NEW_CODEGEN=1 in two places.

Otherwise we either get:

```
No JIT compiler supported on this platform/configuration
```

or an error that there's no IR in the binary.