### PR TITLE
Add `-ao 1` to yk-config invocations to get more optimisations.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,8 @@ ifneq ($(strip $(YK_BUILD_TYPE)),)
 CC=		`yk-config ${YK_BUILD_TYPE} --cc`
 AR=		`yk-config ${YK_BUILD_TYPE} --ar` rcu
 RANLIB=		`yk-config ${YK_BUILD_TYPE} --ranlib`
-CFLAGS=		`yk-config ${YK_BUILD_TYPE} --cflags --cppflags` -O0 -Wall -Wextra -DLUA_COMPAT_5_3 -DUSE_YK -DLUA_USE_JUMPTABLE=0
-LDFLAGS=	`yk-config ${YK_BUILD_TYPE} --ldflags` $(SYSLDFLAGS)
+CFLAGS=		`yk-config ${YK_BUILD_TYPE} --ao 1 --cflags --cppflags` -O0 -Wall -Wextra -DLUA_COMPAT_5_3 -DUSE_YK -DLUA_USE_JUMPTABLE=0
+LDFLAGS=	`yk-config ${YK_BUILD_TYPE} --ao 1 --ldflags` $(SYSLDFLAGS)
 LIBS=		`yk-config ${YK_BUILD_TYPE} --libs` -lm $(SYSLIBS)
 endif
 


### PR DESCRIPTION
Requires https://github.com/ykjit/yk/pull/1400

(Hopefully this is short lived. Soon I hope to be able to allow the user to pass an arbitrary -ON instead of this)