### PR TITLE
Use -O2.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ PLAT= guess
 #
 # When building against the Yk JIT, this is passed in CFLAGS *and* LDFLAGS so
 # that it applies to both the pre-link and link-time pipelines.
-OPTFLAGS=-O1
+OPTFLAGS=-O2
 
 CC= gcc -std=gnu99
 CFLAGS= ${OPTFLAGS} -Wall -Wextra -DLUA_COMPAT_5_3 $(SYSCFLAGS) $(MYCFLAGS)


### PR DESCRIPTION
Both the Lua tests and the benchmarks all now work with -O2, so we may aw well use it.

As we learned the other week, a higher AOT optimisation level leads to smaller AOT IR, which in turn makes smaller JIT IR traces, which in theory we should be able to optimise better.

Very quick benchmarking suggests this doesn't always speed us up yet.

E.g. Richards ~9% speedup, BigLoop ~4% slowdown.