### PR TITLE
Promote instructions.

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1133,13 +1133,23 @@ void luaV_finishOp (lua_State *L) {
 
 
 /* fetch an instruction and prepare its execution */
-#define vmfetch()	{ \
+#ifdef USE_YK
+#  define vmfetch()	{ \
   if (l_unlikely(trap)) {  /* stack reallocation or hooks? */ \
     trap = luaG_traceexec(L, pc);  /* handle hooks */ \
     updatebase(ci);  /* correct stack */ \
   } \
-  i = *(pc++); \
+  i = (Instruction) yk_promote(*(pc++)); \
 }
+#else
+#  define vmfetch()	{ \
+  if (l_unlikely(trap)) {  /* stack reallocation or hooks? */ \
+    trap = luaG_traceexec(L, pc);  /* handle hooks */ \
+    updatebase(ci);  /* correct stack */ \
+  } \
+  i = (Instruction) *(pc++); \
+}
+#endif
 
 #define vmdispatch(o)	switch(o)
 #define vmcase(l)	case l:


### PR DESCRIPTION
This allows yk to constant fold a lot of the resulting instruction decoding. The benefits of doing so can be significant: it speeds big_loop.lua up by about 38%!

Needs https://github.com/ykjit/yk/pull/1441 to be merged first.