### PR TITLE
Use the `pcRel` macro to compute the current pc.

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1223,7 +1223,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
 #ifdef USE_YK
     YkLocation *ykloc = NULL;
     if (GET_OPCODE(i) == OP_FORLOOP || GET_OPCODE(i) == OP_TFORLOOP)
-      ykloc = &cl->p->yklocs[pc - cl->p->code];
+      ykloc = &cl->p->yklocs[pcRel(pc, cl->p)];
     yk_mt_control_point(G(L)->yk_mt, ykloc);
 #endif
     #if 0


### PR DESCRIPTION
The line of code in this commit was off-by-one, though in a way that didn't undermine the correctness of yk per se, since we were always off-by-one. However, it would have meant that we wrote to the word immediately past the end of an allocation, which is UB.

The cause of this is the `vmfetch` macro, executed before the line of code changed by this commit which increments `pc`: thus by the time we execute the line of code in this commit, `pc` no longer points to the actual `pc` we wanted, but one after it. The `pcRel` macro does the necessary magic (i.e. subtracting 1) to resolve this.