### PR TITLE
Revert "Ensure backwards jumps get a yk_location."

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1222,11 +1222,8 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
     vmfetch();
 #ifdef USE_YK
     YkLocation *ykloc = NULL;
-    if ((GET_OPCODE(i) == OP_FORLOOP) ||
-        (GET_OPCODE(i) == OP_TFORLOOP) ||
-        ((GET_OPCODE(i) == OP_JMP) && (GETARG_sJ(i) < 0))) {
+    if (GET_OPCODE(i) == OP_FORLOOP || GET_OPCODE(i) == OP_TFORLOOP)
       ykloc = &cl->p->yklocs[pcRel(pc, cl->p)];
-    }
     yk_mt_control_point(G(L)->yk_mt, ykloc);
 #endif
     #if 0


### PR DESCRIPTION
This reverts commit eb13d42e773a07192e4891c630e1acd44e7f745e.

This change either causes, or exposes bugs in the system and is blocking CI.