### PR TITLE
Revert "Reapply "Ensure backwards jumps get a yk_location.""

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1222,11 +1222,8 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
     vmfetch();
 #ifdef USE_YK
     YkLocation *ykloc = NULL;
-    if ((GET_OPCODE(i) == OP_FORLOOP) ||
-        (GET_OPCODE(i) == OP_TFORLOOP) ||
-        ((GET_OPCODE(i) == OP_JMP) && (GETARG_sJ(i) < 0))) {
+    if (GET_OPCODE(i) == OP_FORLOOP || GET_OPCODE(i) == OP_TFORLOOP)
       ykloc = &cl->p->yklocs[pcRel(pc, cl->p)];
-    }
     yk_mt_control_point(G(L)->yk_mt, ykloc);
 #endif
     #if 0


### PR DESCRIPTION
This reverts commit c7bf29f4258a53819aedf83676339231f2776f15.

We're clearly not ready for this yet and we should not try remerging until we've convinced ourselves that long `try_repeat`s will succeed.