### PR TITLE
Rethink how we identify loops.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -24,6 +24,12 @@ export PATH=`pwd`/.cargo/bin/:$PATH
 git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/ykjit/yk
 cd yk
 echo "yk commit: $(git show -s --format=%H)"
+cat << EOF >> Cargo.toml
+[profile.release-with-asserts]
+inherits = "release"
+debug-assertions = true
+overflow-checks = true
+EOF
 
 cd ykllvm
 ykllvm_hash=$(git rev-parse HEAD)
@@ -45,11 +51,11 @@ fi
 cd ..
 
 YKB_YKLLVM_BUILD_ARGS="define:CMAKE_C_COMPILER=/usr/bin/clang,define:CMAKE_CXX_COMPILER=/usr/bin/clang++" \
-    cargo build
+    cargo build --profile release-with-asserts
 export PATH=`pwd`/bin:${PATH}
 cd ..
 
-YK_BUILD_TYPE=debug make -j `nproc`
+YK_BUILD_TYPE=release-with-asserts make -j `nproc`
 
 # Run the bundled test suite.
 cd tests

--- a/src/lcode.c
+++ b/src/lcode.c
@@ -390,7 +390,11 @@ int luaK_code (FuncState *fs, Instruction i) {
 #ifdef USE_YK
   luaM_growvector(fs->ls->L, f->yklocs, pc, f->sizeyklocs, YkLocation,
                   MAX_INT, "yklocs");
-  f->yklocs[pc] = yk_location_new();
+  f->yklocs[pc] = yk_location_null();
+  if ((GET_OPCODE(i) == OP_JMP) && (GETARG_sJ(i) < 0))
+    f->yklocs[pc + GETARG_sJ(i)] = yk_location_new();
+  if (GET_OPCODE(i) == OP_FORLOOP)
+    f->yklocs[pc - GETARG_Bx(i) - 2] = yk_location_new();
 #endif
   savelineinfo(fs, f, fs->ls->lastline);
   return pc;  /* index of new instruction */

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1221,9 +1221,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
     Instruction i;  /* instruction being executed */
     vmfetch();
 #ifdef USE_YK
-    YkLocation *ykloc = NULL;
-    if (GET_OPCODE(i) == OP_FORLOOP || GET_OPCODE(i) == OP_TFORLOOP)
-      ykloc = &cl->p->yklocs[pcRel(pc, cl->p)];
+    YkLocation *ykloc = &cl->p->yklocs[pcRel(pc, cl->p)];
     yk_mt_control_point(G(L)->yk_mt, ykloc);
 #endif
     #if 0


### PR DESCRIPTION
[Needs https://github.com/ykjit/yk/pull/1606 merged first.]

This commit, small though it is, makes two changes to how we inform yk about Lua loops:

  1. We now calculate where loops start when creating bytecode (rather than continually examining every opcode in the main loop).

  2. We now identify the beginning of the first instruction in a loop as the start of a loop. Previously we identified the beginning of the last instruction in a loop as the start of the loop.

The last change can make ~10% difference on some of the benchmarks I tried, because the trace we get back is both less likely to deopt at the "wrong points" and is more amenable to trace optimisation.