### PR TITLE
Use a version number for idempotency.

### DIFF
--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -22,6 +22,9 @@
 #include "lobject.h"
 #include "lstate.h"
 
+#ifdef USE_YK
+uint64_t global_proto_version = 0;
+#endif
 
 
 CClosure *luaF_newCclosure (lua_State *L, int nupvals) {
@@ -263,12 +266,16 @@ Proto *luaF_newproto (lua_State *L) {
 #ifdef USE_YK
   f->yklocs = NULL;
   f->sizeyklocs = 0;
+  f->proto_version = global_proto_version;
 #endif
   return f;
 }
 
 
 void luaF_freeproto (lua_State *L, Proto *f) {
+#ifdef USE_YK
+  global_proto_version++;
+#endif
   luaM_freearray(L, f->code, f->sizecode);
   luaM_freearray(L, f->p, f->sizep);
   luaM_freearray(L, f->k, f->sizek);

--- a/src/lfunc.h
+++ b/src/lfunc.h
@@ -10,6 +10,13 @@
 
 #include "lobject.h"
 
+#ifdef USE_YK
+// Every time a function is deleted, we crank this integer. Thus if two
+// `Proto`s are allocated -- at different times! -- at the same address, the
+// idempotent `load_inst` function won't consider them to be the same function.
+extern uint64_t global_proto_version;
+#endif
+
 
 #define sizeCclosure(n)	(cast_int(offsetof(CClosure, upvalue)) + \
                          cast_int(sizeof(TValue)) * (n))

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -571,6 +571,7 @@ typedef struct Proto {
 #ifdef USE_YK
   YkLocation *yklocs; /* One 'YkLocation' per instruction in 'code' */
   int sizeyklocs; /* size of 'yklocs' */
+  uint64_t proto_version; /* What 'Proto Version' was this created under? */
 #endif
   struct Proto **p;  /* functions defined inside the function */
   Upvaldesc *upvalues;  /* upvalue information */


### PR DESCRIPTION
It can happen -- we've seen it! -- that two `Proto`s, allocated at different times, end up at the same address P. `load_inst` then implicitly treats them as the same `Proto` even though they might be completely different.

In this commit, we attach a "proto version" to every `Proto`, which records what the `global_proto_version` was when the `Proto` was constructed. Every time a `Proto` is freed, we increment this version. Thus two `Proto`s at the same address will always have different "proto versions", invalidating any traces specialised to the old `Proto`, while not invaldating traces for other `Proto`s that are still alive.