### PR TITLE
Add hot location debug strings support to yklua.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ export YK_BUILD_TYPE=<debug|release>
 make -j "$(nproc)"
 ```
 
+To build with hot location debug support, define the `YK_HL_DEBUG` preprocessor
+macro. You can do this when you invoke `make` like this:
+
+```shell
+make -j "$(nproc)" MYCFLAGS=-DYK_HL_DEBUG
+```
 
 ## Run
 


### PR DESCRIPTION
Lua-level source lines are attached to hot locations.

Example output:
```
Starting richards benchmark ...
yk-jit-event: start-tracing: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: stop-tracing: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:60: while NO_WORK ~= link do
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:60: while NO_WORK ~= link do
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:60: while NO_WORK ~= link do
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:60: while NO_WORK ~= link do
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:60: while NO_WORK ~= link do
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:60: while NO_WORK ~= link do
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:395: data.count = data.count + 1
yk-warning: tracing-aborted: encountered compiled trace: ./richards.lua:489: while self.current_task ~= NO_TASK do
yk-jit-event: start-tracing: ./richards.lua:395: data.count = data.count + 1
yk-jit-event: stop-tracing: ./richards.lua:395: data.count = data.count + 1
yk-jit-event: enter-jit-code: ./richards.lua:395: data.count = data.count + 1
...
```