### PR TITLE
Rethink debug strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is the reference Lua interpreter with the Yk JIT retrofitted.
 
 This is experimental!
 
+
 ## Build
 
 GNU make is required.
@@ -15,15 +16,16 @@ export YK_BUILD_TYPE=<debug|release>
 make -j "$(nproc)"
 ```
 
-To build with hot location debug support, define the `YK_HL_DEBUG` preprocessor
-macro. You can do this when you invoke `make` like this:
+To build with debug string support for both `HotLocation`s and per Lua
+`Instruction` in a trace, define the `YKLUA_DEBUG_STRS` preprocessor macro:
 
 ```shell
-make -j "$(nproc)" MYCFLAGS=-DYK_HL_DEBUG
+make -j "$(nproc)" MYCFLAGS=-DYKLUA_DEBUG_STRS
 ```
 
-With an undefined value, or a value of `1`, `YK_HL_DEBUG` will put full path
-names into the debug output. To output only leaf names, set `-DYK_HL_DEBUG=2`.
+With an unspecified value, or a value of `1`, `YKLUA_DEBUG_STRS` will put full path
+names into the debug output. To output only leaf names, set `-DYKLUA_DEBUG_STRS=2`.
+
 
 ## Run
 

--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -265,12 +265,19 @@ Proto *luaF_newproto (lua_State *L) {
   f->source = NULL;
 #ifdef USE_YK
   f->yklocs = NULL;
+#ifdef YKLUA_DEBUG_STRS
+  f->instdebugstrs = NULL;
+#endif
   f->sizeyklocs = 0;
   f->proto_version = global_proto_version;
 #endif
   return f;
 }
 
+
+#ifdef USE_YK
+#include <stdlib.h>
+#endif
 
 void luaF_freeproto (lua_State *L, Proto *f) {
 #ifdef USE_YK
@@ -285,6 +292,11 @@ void luaF_freeproto (lua_State *L, Proto *f) {
   luaM_freearray(L, f->upvalues, f->sizeupvalues);
 #ifdef USE_YK
   luaM_freearray(L, f->yklocs, f->sizeyklocs);
+#ifdef YKLUA_DEBUG_STRS
+  for (int i = 0; i < f->sizeyklocs; i++)
+    free(f->instdebugstrs[i]);
+  luaM_freearray(L, f->instdebugstrs, f->sizeyklocs);
+#endif
 #endif
   luaM_free(L, f);
 }

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -570,7 +570,10 @@ typedef struct Proto {
   Instruction *code;  /* opcodes */
 #ifdef USE_YK
   YkLocation *yklocs; /* One 'YkLocation' per instruction in 'code' */
-  int sizeyklocs; /* size of 'yklocs' */
+#ifdef YKLUA_DEBUG_STRS
+  char **instdebugstrs; /* One `char *` per instruction in `code` */
+#endif
+  int sizeyklocs; /* size of 'yklocs' and (if present) `instDebugStr` */
   uint64_t proto_version; /* What 'Proto Version' was this created under? */
 #endif
   struct Proto **p;  /* functions defined inside the function */

--- a/src/lparser.h
+++ b/src/lparser.h
@@ -167,7 +167,7 @@ LUAI_FUNC int luaY_nvarstack (FuncState *fs);
 LUAI_FUNC LClosure *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff,
                                  Dyndata *dyd, const char *name, int firstchar);
 #ifdef USE_YK
-LUAI_FUNC void assign_yklocs(lua_State *L, Proto *f, int num_insts);
+LUAI_FUNC void ykifyCode(lua_State *L, Proto *f, int num_insts);
 #endif
 
 

--- a/src/lundump.c
+++ b/src/lundump.c
@@ -154,7 +154,7 @@ static void loadCode (LoadState *S, Proto *f) {
   loadVector(S, f->code, n);
 #ifdef USE_YK
    /* FIXME: Ideally we'd persist the locations across a dump+undump too */
-  assign_yklocs(S->L, f, n);
+  ykifyCode(S->L, f, n);
 #endif
 }
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1230,6 +1230,9 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
   /* main loop of interpreter */
   for (;;) {
     Instruction i;  /* instruction being executed */
+#ifdef YKLUA_DEBUG_STRS
+    yk_debug_str(cl->p->instdebugstrs[cast_int(pc - cl->p->code)]);
+#endif
     vmfetch();
 #ifdef USE_YK
     YkLocation *ykloc = &cl->p->yklocs[pcRel(pc, cl->p)];


### PR DESCRIPTION
This commit changes how yklua creates debug strings to help a yklua/yk developer understand what's going on in traces. The major parts of this commit are.

  1. Move from printing source lines to printing opcodes.
  2. Output yk "debug strings" in traces.

As will shortly become obvious, this commit extends debugging output beyond `HotLocation`s, so the macro has become `YKLUA_DEBUG_STRS`. Since in tests -- which will probably be the main use of this macro I suspect -- full pathnames are a problem, defining this with a value of `2` only outputs leaf names.

## Move from printing source lines to printing opcodes.

Previously debug strings contained Lua source code e.g.:

```
x.lua:41: if x < y
```

This caused two problems:

  1. One source line can generate lots of IR so this gave poor visibility into what was going on: often one source line would be responsible for nearly all debug strings seen at runtime.
  2. There is a bug where the `fgets` used to read source code sometimes led (much later) to a segfault. Exactly why this happens is a bit of a mystery to me. It doesn't seem to be `errno` related. Perhaps it's shadowstack related? I spent a while on this, but eventually gave up, because I realised that solving problem (1) means that it's no longer really worth printing out source lines anyway.

The solution this commit alights upon is to print out opcodes. So the example above might become something like:

```
x.lua:41: OP_LOADI
x.lua:41: OP_EQ
```

and so on. In other words, one source line is now decomposed into its constituent opcodes. This makes much more fine-grained tests possible, and has already given me a much greater insight into what tracing is doing.

## Output yk "debug strings" in traces.

I have not found debug strings in `HotLocation`s to give me as much insight as I expected. Instead, it's much more useful to know what opcodes have been traced. So this commit leads to traces like this:

```
--- Begin jit-pre-opt ---
  ...
  ; debug_str: nested_loops.lua:33: ADDK
  %63: i32 = and %45, 127i32
  ...
  %139: ptr = load %138
  ; debug_str: nested_loops.lua:32: FORLOOP
  %141: i32 = and %108, 127i32
  ...
--- End jit-pre-opt ---
```

This has already given me much greater insight into what's being traced and thrown light onto factors I had either misunderstood or been unaware of.