### PR TITLE
Promote big constants for arithmetic operations.

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -985,10 +985,22 @@ void luaV_finishOp (lua_State *L) {
 /*
 ** Arithmetic operations with K operands.
 */
+#ifdef USE_YK
+#define op_arithK(L,iop,fop) {  \
+  TValue *v1 = vRB(i);  \
+  TValue *v2 = KC(i); lua_assert(ttisnumber(v2));  \
+  StkId ra = RA(i); \
+  if (ttisinteger(v1) && ttisinteger(v2)) {  \
+    lua_Integer i1 = ivalue(v1); lua_Integer i2 = yk_promote(ivalue(v2));  \
+    pc++; setivalue(s2v(ra), iop(L, i1, i2));  \
+  }  \
+  else op_arithf_aux(L, v1, v2, fop); }
+#else
 #define op_arithK(L,iop,fop) {  \
   TValue *v1 = vRB(i);  \
   TValue *v2 = KC(i); lua_assert(ttisnumber(v2));  \
   op_arith_aux(L, v1, v2, iop, fop); }
+#endif
 
 
 /*


### PR DESCRIPTION
This PR adds promotion for big constants in Lua's arithmetic operations. For this we change `op_arithK` by inlining `op_arith_aux` and adding `yk_promote` to the second operand.

Using the following lua program I can confirm that this indeed promotes big constants:
```lua
local sum = 0
for _ = 1,100000 do
    sum = sum + 420000
end
print(sum)
```

However, when running `yk-benchmarks` I cannot see any significant performance improvements. On the contrary `bigloop` and `permute` take a 10% performance hit. Looking into `bigloop` I cannot figure out where this performance hit comes from as the jit-asm of both traces is nearly identical, and `YKD_STATS` tells us that it is indeed trace execution that takes the hit. I've attached the output for a normal run of bigloop and a run with the new promote code, printing out `jit-pre-op`, `jit-asm`, and `YKD_STATS`.

[NORMAL.txt](https://github.com/user-attachments/files/19865374/NORMAL.txt)
[PROMOTEK.txt](https://github.com/user-attachments/files/19865377/PROMOTEK.txt)
