### PR TITLE
Add a `.dockerignore`.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
Without this, one can easily end up coping over prebuilt binaries into a docker image, with non-hilarious results.