### PR TITLE
Mark critical, stable, functions as `unroll_safe`.

### DIFF
--- a/src/ldo.c
+++ b/src/ldo.c
@@ -540,6 +540,7 @@ l_sinline int precallC (lua_State *L, StkId func, int nresults,
 ** (so that it includes the function itself). Return the number of
 ** results, if it was a C function, or -1 for a Lua function.
 */
+__attribute__((yk_unroll_safe))
 int luaD_pretailcall (lua_State *L, CallInfo *ci, StkId func,
                                     int narg1, int delta) {
  retry:
@@ -597,6 +598,7 @@ int luaD_pretailcall (lua_State *L, CallInfo *ci, StkId func,
 ** returns NULL, with all the results on the stack, starting at the
 ** original function position.
 */
+__attribute__((yk_unroll_safe))
 CallInfo *luaD_precall (lua_State *L, StkId func, int nresults) {
  retry:
   switch (ttypetag(s2v(func))) {

--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -227,6 +227,7 @@ static void poptbclist (lua_State *L) {
 ** Close all upvalues and to-be-closed variables up to the given stack
 ** level. Return restored 'level'.
 */
+__attribute__((yk_unroll_safe))
 StkId luaF_close (lua_State *L, StkId level, int status, int yy) {
   ptrdiff_t levelrel = savestack(L, level);
   luaF_closeupval(L, level);  /* first, close the upvalues */

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -287,6 +287,7 @@ static int floatforloop (StkId ra) {
 ** if 'slot' is NULL, 't' is not a table; otherwise, 'slot' points to
 ** t[k] entry (which must be empty).
 */
+__attribute__((yk_unroll_safe))
 void luaV_finishget (lua_State *L, const TValue *t, TValue *key, StkId val,
                       const TValue *slot) {
   int loop;  /* counter to avoid infinite loops */


### PR DESCRIPTION
These functions contain loops and (1) tend to appear in tight loops (2) are largely or wholly consistent from one iteration to the next. On our benchmark suite, we see the following speed-ups (as percentages, where > 0 is better):

| | |
|-|-|
|BigLoop    | 0.22 | 
|Bounce     | 6.61 |
|CD         | 4.84 |
|DeltaBlue  | 2.75 |
|HashIds    | 9.81 |
|Havlak     | 2.72 |
|Heightmap  | 0.48 |
|Json       | 3.85 |
|List       | -2.08|
|LuLPeg     |      |
|Mandelbrot | -0.74|
|NBody      | -0.73|
|Permute    | -6.45|
|Queens     | 8.74 |
|Richards   | 8.01 |
|Sieve      | 1.35 |
|Storage    | 1.02 |
|Towers     | 2.87 |


Pretty much only bigloop isn't impacted (quelle surprise). 4 benchmarks get slower, but only Permute noticeably so (List a little bit, but less so). 5 benchmarks get much faster (5-10%), 3-4 get fairly faster (2.5-5%). Overall, this seems meaningfully better overall to me.

However! LuLPeg borks with:

```
LuLPeg/lulpeg.lua:979: bad argument #2 to 's_byte' (number expected, got string)
```

This commit shouldn't be introducing a new bug (per se), but it probably is highlighting an existing bug that's been previously hidden.

@ptersilie Do you think you can have a look to see what the cause of this might be? Nothing obvious has jumped out at me TBH. The "critical" thing seems to be the annotation to luaD_precall -- remove that and the bug goes away. However, that might not tell us very much because the problem is probably somewhere in (or beneath) `precallC` (but I might be wrong).