### PR TITLE
Split `setnodevector`.

### DIFF
--- a/src/ltable.c
+++ b/src/ltable.c
@@ -477,13 +477,7 @@ static int numusehash (const Table *t, unsigned int *nums, unsigned int *pna) {
 ** comparison ensures that the shift in the second one does not
 ** overflow.
 */
-static void setnodevector (lua_State *L, Table *t, unsigned int size) {
-  if (size == 0) {  /* no elements to hash part? */
-    t->node = cast(Node *, dummynode);  /* use common 'dummynode' */
-    t->lsizenode = 0;
-    t->lastfree = NULL;  /* signal that it is using dummy node */
-  }
-  else {
+static void setnodevector_full (lua_State *L, Table *t, unsigned int size) {
     int i;
     int lsize = luaO_ceillog2(size);
     if (lsize > MAXHBITS || (1u << lsize) > MAXHSIZE)
@@ -498,6 +492,16 @@ static void setnodevector (lua_State *L, Table *t, unsigned int size) {
     }
     t->lsizenode = cast_byte(lsize);
     t->lastfree = gnode(t, size);  /* all positions are free */
+}
+
+static void setnodevector (lua_State *L, Table *t, unsigned int size) {
+  if (size == 0) {  /* no elements to hash part? */
+    t->node = cast(Node *, dummynode);  /* use common 'dummynode' */
+    t->lsizenode = 0;
+    t->lastfree = NULL;  /* signal that it is using dummy node */
+  }
+  else {
+    setnodevector_full(L, t, size);
   }
 }
 


### PR DESCRIPTION
The common case, by far, is `size == 0` so this function was being outlined mostly for no good reason. This commit splits it into two: the common case can be inlined by yk, with the uncommon case leading to a `call`.

This leads to a small, but just about measurable speed up, on some benchmarks (including ~3% on Richards).