### PR TITLE
Assign locations to TFORLOOP loops.

### DIFF
--- a/src/lparser.c
+++ b/src/lparser.c
@@ -846,7 +846,7 @@ void ykifyCode(lua_State *L, Proto *f, int num_insts) {
     if ((GET_OPCODE(i) == OP_JMP) && (GETARG_sJ(i) < 0)) {
       lua_assert(GETARG_sJ(i) + pc + 2 - 1 < pc);
       loc_pc = GETARG_sJ(i) + pc + 2 - 1;
-    } else if (GET_OPCODE(i) == OP_FORLOOP) {
+    } else if ((GET_OPCODE(i) == OP_FORLOOP) || (GET_OPCODE(i) == OP_TFORLOOP)) {
       lua_assert(pc - GETARG_Bx(i) + 2 - 1 < pc);
       loc_pc = pc - GETARG_Bx(i) + 2 - 1;
     } else {


### PR DESCRIPTION
FORLOOP (which yklua already recognises) is for numeric looping, e.g.:
```
for i = 1, 10; do ...
```

TFORLOOP is used for other loops, e.g.:
```
for line in io.lines("fasta1000000.txt") do ...
```

Peformance impact (vs. main, based on 3 invocations of 10 iterations):
```
 Benchmark                  Datum0 (ms)  Datum1 (ms)  Ratio  Summary
 revcomp/YkLua/default      2458         1850         0.75   24.75% faster
 knucleotide/YkLua/default  1846         1594         0.86   13.66% faster
 Richards/YkLua/100         4471         4147         0.93   7.24% faster
 LuLPeg/YkLua/default       3357         3252         0.97   3.10% faster
 Json/YkLua/100             2549         2489         0.98   2.37% faster
 Queens/YkLua/1000          504          493          0.98   2.24% faster
 HashIds/YkLua/6000         2873         2829         0.98   1.56% faster
 binarytrees/YkLua/15       3993         3979         1.00   0.36% faster
 Storage/YkLua/1000         9815         9791         1.00   0.24% faster
 CD/YkLua/250               8969         8955         1.00   0.16% faster
 Heightmap/YkLua/2000       749          749          1.00   0.01% faster
 fasta/YkLua/500000         841          841          1.00   0.00% slower
 NBody/YkLua/250000         488          488          1.00   0.04% slower
 spectralnorm/YkLua/1000    902          907          1.01   0.51% slower
 Mandelbrot/YkLua/500       129          130          1.01   0.65% slower
 Sieve/YkLua/3000           468          472          1.01   0.84% slower
 Towers/YkLua/600           908          918          1.01   1.12% slower
 BigLoop/YkLua/1000000000   1617         1641         1.02   1.50% slower
 Havlak/YkLua/1500          18926        19245        1.02   1.69% slower
 Permute/YkLua/1000         790          804          1.02   1.75% slower
 fannkuchredux/YkLua/10     1223         1250         1.02   2.24% slower
 DeltaBlue/YkLua/12000      1949         2000         1.03   2.61% slower
 List/YkLua/1500            832          859          1.03   3.33% slower
 Bounce/YkLua/1500          1142         1186         1.04   3.88% slower
 ```