### PR TITLE
Mark as `yk_outline` functions which we don't want to trace.

### DIFF
--- a/src/lgc.c
+++ b/src/lgc.c
@@ -1723,6 +1723,7 @@ static void fullinc (lua_State *L, global_State *g) {
 ** some operations which could change the interpreter state in some
 ** unexpected ways (running finalizers and shrinking some structures).
 */
+__attribute__((yk_outline))
 void luaC_fullgc (lua_State *L, int isemergency) {
   global_State *g = G(L);
   lua_assert(!g->gcemergency);

--- a/src/lmem.c
+++ b/src/lmem.c
@@ -159,6 +159,7 @@ void luaM_free_ (lua_State *L, void *block, size_t osize) {
 ** In case of allocation fail, this function will do an emergency
 ** collection to free some memory and then try the allocation again.
 */
+__attribute__((yk_outline))
 static void *tryagain (lua_State *L, void *block,
                        size_t osize, size_t nsize) {
   global_State *g = G(L);


### PR DESCRIPTION
Edd's recent analysis suggests that we often end up recording blocks in these functions, even though neither is appropriate for a trace.