### PR TITLE
Promote small ints and floats

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1260,13 +1260,21 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       }
       vmcase(OP_LOADI) {
         StkId ra = RA(i);
+      #ifdef USE_YK
+        lua_Integer b = yk_promote(GETARG_sBx(i));
+      #else
         lua_Integer b = GETARG_sBx(i);
+      #endif
         setivalue(s2v(ra), b);
         vmbreak;
       }
       vmcase(OP_LOADF) {
         StkId ra = RA(i);
+      #ifdef USE_YK
+        int b = yk_promote(GETARG_sBx(i));
+      #else
         int b = GETARG_sBx(i);
+      #endif
         setfltvalue(s2v(ra), cast_num(b));
         vmbreak;
       }


### PR DESCRIPTION
There's no significant results on benchmarks with jitc_yk:

```
confidence level: 99%

 Benchmark                 Datum2 (ms)  Datum1 (ms)  Ratio  Summary           
 json/yklua/100            12943 ± 903  12575 ±  33   0.97  indistinguishable 
 havlak/yklua/1500         76760 ±2049  74648 ± 335   0.97  indistinguishable 
 deltablue/yklua/12000     10165 ± 307   9900 ±  79   0.97  indistinguishable 
 sieve/yklua/3000           3788 ± 127   3717 ±  43   0.98  indistinguishable 
 fannkuchredux/yklua/10    12184 ± 173  11996 ±  86   0.98  indistinguishable 
 bigloop/yklua/1000000000  17302 ± 130  17076 ± 233   0.99  indistinguishable 
 Heightmap/yklua/2000       7367 ± 174   7309 ± 151   0.99  indistinguishable 
 storage/yklua/1000        23687 ± 204  23511 ± 163   0.99  indistinguishable 
 towers/yklua/600           8927 ± 767   8869 ±  85   0.99  indistinguishable 
 binarytrees/yklua/15      11099 ±  33  11044 ±  66   1.00  indistinguishable 
 cd/yklua/250              32622 ±  71  32485 ± 402   1.00  indistinguishable 
 HashIds/yklua/6000         9158 ± 134   9138 ±  33   1.00  indistinguishable 
 mandelbrot/yklua/500       1268 ±   2   1266 ±   2   1.00  indistinguishable 
 LuLPeg/yklua/             14017 ± 159  14012 ± 112   1.00  indistinguishable 
 spectralnorm/yklua/1000    8978 ±  17   8990 ±  60   1.00  indistinguishable 
 bounce/yklua/1500          9001 ± 740   9016 ± 417   1.00  indistinguishable 
 permute/yklua/1000         8017 ± 170   8039 ± 539   1.00  indistinguishable 
 queens/yklua/1000          4847 ± 323   4864 ± 153   1.00  indistinguishable 
 nbody/yklua/250000         4517 ± 306   4545 ±  88   1.01  indistinguishable 
 richards/yklua/100        40452 ± 586  40991 ±1546   1.01  indistinguishable 
 knucleotide/yklua/        12873 ± 229  13118 ± 369   1.02  indistinguishable 
 list/yklua/1500            7380 ± 434   7781 ± 365   1.05  indistinguishable
```

I suspect it's mainly because these ops are almost always followed by loading to the stack, which destroys all our optimisation information at the moment.