### PR TITLE
Add -fno-plt optimisation to CFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,8 @@ PLAT= guess
 OPTFLAGS=-O2
 
 CC= gcc -std=gnu99
-CFLAGS= ${OPTFLAGS} -Wall -Wextra -DLUA_COMPAT_5_3 $(SYSCFLAGS) $(MYCFLAGS)
+# -fno-plt: bypass PLT for faster calls
+CFLAGS= ${OPTFLAGS} -Wall -Wextra -fno-plt -DLUA_COMPAT_5_3 $(SYSCFLAGS) $(MYCFLAGS)
 LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)
 


### PR DESCRIPTION
Add `-fno-plt` compiler flag to yklua's Makefile to eliminate PLT (Procedure Linkage Table) indirection for calls from yklua to libykcapi functions.

This change **partially eliminates PLT overhead**, with improvements for 3 benchmarks when running with the interpreter only (JIT disabled):

## Summary

Key reductions:
- `__yk_promote_ptr@plt` overhead: **1.2–1.5% → 0%** (eliminated)
- `__yk_promote_usize@plt` overhead: **0.8–1.5% → 0%** (eliminated)

**Note**: `__yk_idempotent_promote_i32@plt` and `__ykrt_control_point@plt` stubs persist - I think we'll need to update llvm pass to optimise it (I have a branch for that).

### Perf stats

Note: perf data collected with `YKD_JITC=none`

#### LuLPeg

| PLT Stub                        | Baseline % | Baseline Samples | This Change % | This Change Samples |
|---------------------------------|------------|------------------|---------------|---------------------|
| `__yk_promote_ptr@plt`          | 1.47%      | 3,319            | **0%**        | 0                   |
| `__yk_promote_usize@plt`        | 1.46%      | 3,301            | **0%**        | 0                   |
| `__yk_idempotent_promote_i32@plt` | 1.53%    | 3,443            | 1.43%         | 3,324               |
| `__ykrt_control_point@plt`      | 1.43%      | 3,226            | 1.48%         | 3,430               |

#### Richards

| PLT Stub                        | Baseline % | Baseline Samples | This Change % | This Change Samples |
|---------------------------------|------------|------------------|---------------|---------------------|
| `__yk_promote_ptr@plt`          | 1.24%      | 67               | **0%**        | 0                   |
| `__yk_promote_usize@plt`        | 0.94%      | 51               | **0%**        | 0                   |
| `__yk_idempotent_promote_i32@plt` | 1.14%    | 62               | 1.33%         | 70                  |
| `__ykrt_control_point@plt`      | 1.27%      | 69               | 1.00%         | 53                  |

*Baseline total: 5.4K samples, This Change total: 5.3K samples*

#### Havlak

| PLT Stub                        | Baseline % | Baseline Samples | This Change % | This Change Samples |
|---------------------------------|------------|------------------|---------------|---------------------|
| `__yk_promote_ptr@plt`          | 0.82%      | 2,983            | **0%**        | 0                   |
| `__yk_promote_usize@plt`        | 0.81%      | 2,956            | **0%**        | 0                   |
| `__yk_idempotent_promote_i32@plt` | 0.85%    | 3,111            | 0.81%         | 2,867               |
| `__ykrt_control_point@plt`      | 0.80%      | 2,934            | 0.81%         | 2,888               |

