### PR TITLE
Sprinkle `yk_is_interpreting` as appropriate.

### DIFF
--- a/src/ldo.c
+++ b/src/ldo.c
@@ -574,15 +574,15 @@ int luaD_pretailcall (lua_State *L, CallInfo *ci, StkId func,
       ci->top.p = func + 1 + fsize;  /* top for new function */
       lua_assert(ci->top.p <= L->stack_last.p);
 #ifdef USE_YK
-      // If this is a recursive call and we don't yet have a yk_location,
-      // create one now.
-      if (p->called && yk_location_is_null(p->yklocs[0])) {
-        p->yklocs[0] = yk_location_new();
+      if (yk_is_interpreting()) {
+        // If this is a recursive call and we don't yet have a yk_location,
+        // create one now.
+        if (p->called && yk_location_is_null(p->yklocs[0])) {
+          p->yklocs[0] = yk_location_new();
 #if YKLUA_DEBUG_STRS
-        yk_location_set_debug_str(&p->yklocs[0], p->instdebugstrs[0]);
+          yk_location_set_debug_str(&p->yklocs[0], p->instdebugstrs[0]);
 #endif
-      } else if (!p->called) {
-        p->called = true;
+        }
       }
 #endif
       ci->u.l.savedpc = p->code;  /* starting point */
@@ -631,15 +631,17 @@ CallInfo *luaD_precall (lua_State *L, StkId func, int nresults) {
         setnilvalue(s2v(L->top.p++));  /* complete missing arguments */
       lua_assert(ci->top.p <= L->stack_last.p);
 #ifdef USE_YK
-      // If this is a recursive call and we don't yet have a yk_location,
-      // create one now.
-      if (p->called && yk_location_is_null(p->yklocs[0])) {
-        p->yklocs[0] = yk_location_new();
+      if (yk_is_interpreting()) {
+        // If this is a recursive call and we don't yet have a yk_location,
+        // create one now.
+        if (p->called && yk_location_is_null(p->yklocs[0])) {
+          p->yklocs[0] = yk_location_new();
 #if YKLUA_DEBUG_STRS
-        yk_location_set_debug_str(&p->yklocs[0], p->instdebugstrs[0]);
+          yk_location_set_debug_str(&p->yklocs[0], p->instdebugstrs[0]);
 #endif
-      } else if (!p->called) {
-        p->called = true;
+        } else if (!p->called) {
+          p->called = true;
+        }
       }
 #endif
       return ci;

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1857,7 +1857,9 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         }
        ret:  /* return from a Lua function */
 #ifdef USE_YK
-        cl->p->called = false;
+        if (yk_is_interpreting()) {
+          cl->p->called = false;
+        }
 #endif
         if (ci->callstatus & CIST_FRESH)
           return;  /* end this frame */


### PR DESCRIPTION
Needs https://github.com/ykjit/yk/pull/2113.

This speeds up a number of benchmarks. On b16 I get:

```
 LuLPeg/lua/              11861 ±  79   10287 ± 174   0.87  13.28% faster
 json/lua/100             10952 ± 133   10228 ± 242   0.93  6.61% faster
 storage/lua/1000         22579 ± 156   21776 ± 272   0.96  3.55% faster
 spectralnorm/lua/1000     9132 ±  43    8808 ±  64   0.96  3.55% faster
 havlak/lua/1500          73547 ± 390   70956 ± 223   0.96  3.52% faster
 cd/lua/250               31251 ± 280   30296 ± 265   0.97  3.05% faster
 HashIds/lua/6000          8825 ± 153    8557 ±  97   0.97  3.04% faster
```

b15 is a bit less impressive, but still there are 5 benchmarks in the 3-5% improvement range.