### PR TITLE
Remove `proto_version`.

### DIFF
--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -22,10 +22,6 @@
 #include "lobject.h"
 #include "lstate.h"
 
-#ifdef USE_YK
-uint64_t global_proto_version = 0;
-#endif
-
 
 CClosure *luaF_newCclosure (lua_State *L, int nupvals) {
   GCObject *o = luaC_newobj(L, LUA_VCCL, sizeCclosure(nupvals));
@@ -271,7 +267,6 @@ Proto *luaF_newproto (lua_State *L) {
   f->instdebugstrs = NULL;
 #endif
   f->sizeyklocs = 0;
-  f->proto_version = global_proto_version;
 #endif
   return f;
 }
@@ -282,9 +277,6 @@ Proto *luaF_newproto (lua_State *L) {
 #endif
 
 void luaF_freeproto (lua_State *L, Proto *f) {
-#ifdef USE_YK
-  global_proto_version++;
-#endif
   luaM_freearray(L, f->code, f->sizecode);
   luaM_freearray(L, f->p, f->sizep);
   luaM_freearray(L, f->k, f->sizek);

--- a/src/lfunc.h
+++ b/src/lfunc.h
@@ -10,13 +10,6 @@
 
 #include "lobject.h"
 
-#ifdef USE_YK
-// Every time a function is deleted, we crank this integer. Thus if two
-// `Proto`s are allocated -- at different times! -- at the same address, the
-// idempotent `load_inst` function won't consider them to be the same function.
-extern uint64_t global_proto_version;
-#endif
-
 
 #define sizeCclosure(n)	(cast_int(offsetof(CClosure, upvalue)) + \
                          cast_int(sizeof(TValue)) * (n))

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -581,7 +581,6 @@ typedef struct Proto {
   char **instdebugstrs; /* One `char *` per instruction in `code` */
 #endif
   int sizeyklocs; /* size of 'yklocs' and (if present) `instDebugStr` */
-  uint64_t proto_version; /* What 'Proto Version' was this created under? */
 #endif
   struct Proto **p;  /* functions defined inside the function */
   Upvaldesc *upvalues;  /* upvalue information */

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1173,8 +1173,8 @@ void luaV_finishOp (lua_State *L) {
 #define NOOPT_VAL(X) asm volatile("" : "+r,m"(X) : : "memory");
 // Elide instruction lookup.
 __attribute__((yk_idempotent))
-Instruction load_inst(uint64_t pv, const Instruction *pc) {
-  NOOPT_VAL(pv);
+Instruction load_inst(const Instruction *pc) {
+  NOOPT_VAL(pc);
   return *pc;
 }
 
@@ -1184,8 +1184,7 @@ Instruction load_inst(uint64_t pv, const Instruction *pc) {
     updatebase(ci);  /* correct stack */ \
   } \
   pc = (Instruction *) yk_promote((void *) pc); \
-  uint64_t pv = yk_promote(cl_proto_version); \
-  i = load_inst(pv, pc); \
+  i = load_inst(pc); \
   pc++; \
 }
 #else
@@ -1216,9 +1215,6 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
   trap = L->hookmask;
  returning:  /* trap already set */
   cl = clLvalue(s2v(ci->func.p));
-#ifdef USE_YK
-  uint64_t cl_proto_version = cl->p->proto_version;
-#endif
   k = cl->p->k;
   pc = ci->u.l.savedpc;
   if (l_unlikely(trap)) {


### PR DESCRIPTION
I added this ages back in response to a crash, when I laboured under the incorrect belief that Lua allows opcode sequences to changed. It doesn't. The fact that this once fixed a crash is a pure coincidence!

Notice also that this comment is wrong:

> Thus if two `Proto`s are allocated -- at different times! -- at the
> same address

`yk_idempotent`, by definition, is only in the context of a given `Location` and trace: it can't return different values given this context.

This is a small but measurable speed-up for benchmarks that spend a reasonable amount of time in the interpreter.