### PR TITLE
Only call `load_inst` during tracing.

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1183,9 +1183,13 @@ Instruction load_inst(uint64_t pv, const Instruction *pc) {
     trap = luaG_traceexec(L, pc);  /* handle hooks */ \
     updatebase(ci);  /* correct stack */ \
   } \
-  pc = (Instruction *) yk_promote((void *) pc); \
-  uint64_t pv = yk_promote(cl_proto_version); \
-  i = load_inst(pv, pc); \
+  if (yk_is_interpreting()) { \
+    i = *pc; \
+  } else { \
+    pc = (Instruction *) yk_promote((void *) pc); \
+    uint64_t pv = yk_promote(cl_proto_version); \
+    i = load_inst(pv, pc); \
+  } \
   pc++; \
 }
 #else


### PR DESCRIPTION
When we're interpreting, `load_inst` and its associated `yk_promote`s are slow. This commit only pays that cost during tracing: this speeds up json by ~4% and a few other benchmarks by a smaller amount (possibly statistically insignificant, but I think there's a small, genuine signal there).