### PR TITLE
Remove pointless promotes.

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -905,7 +905,7 @@ void luaV_finishOp (lua_State *L) {
 #  define op_arithI(L,iop,fop) {  \
   StkId ra = RA(i); \
   TValue *v1 = vRB(i);  \
-  int imm = yk_promote(GETARG_sC(i));  \
+  int imm = GETARG_sC(i);  \
   if (ttisinteger(v1)) {  \
     lua_Integer iv1 = ivalue(v1);  \
     pc++; setivalue(s2v(ra), iop(L, iv1, imm));  \
@@ -1049,7 +1049,7 @@ void luaV_finishOp (lua_State *L) {
 #  define op_orderI(L,opi,opf,inv,tm) {  \
   StkId ra = RA(i); \
   int cond;  \
-  int im = yk_promote(GETARG_sB(i));  \
+  int im = GETARG_sB(i);  \
   if (ttisinteger(s2v(ra)))  \
     cond = opi(ivalue(s2v(ra)), im);  \
   else if (ttisfloat(s2v(ra))) {  \
@@ -1598,11 +1598,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       vmcase(OP_MMBINI) {
         StkId ra = RA(i);
         Instruction pi = *(pc - 2);  /* original arith. expression */
-#ifdef USE_YK
-        int imm = yk_promote(GETARG_sB(i));
-#else
         int imm = GETARG_sB(i);
-#endif
         TMS tm = (TMS)GETARG_C(i);
         int flip = GETARG_k(i);
         StkId result = RA(pi);
@@ -1709,11 +1705,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       vmcase(OP_EQI) {
         StkId ra = RA(i);
         int cond;
-#ifdef USE_YK
-        int im = yk_promote(GETARG_sB(i));
-#else
         int im = GETARG_sB(i);
-#endif
         if (ttisinteger(s2v(ra)))
           cond = (ivalue(s2v(ra)) == im);
         else if (ttisfloat(s2v(ra)))


### PR DESCRIPTION
These all promote values that the optimiser can prove are constant as a result of `load_inst`. My guess -- it's been a while! -- is that explicitly promoting these was more necessary when the optimiser was less capable.