### PR TITLE
Put the location immediately after `FORPREP`.

### DIFF
--- a/src/lparser.c
+++ b/src/lparser.c
@@ -922,7 +922,7 @@ void ykifyCode(lua_State *L, Proto *f, int num_insts) {
       loc_pc = GETARG_sJ(i) + pc + 2 - 1;
     } else if ((GET_OPCODE(i) == OP_FORLOOP) || (GET_OPCODE(i) == OP_TFORLOOP)) {
       lua_assert(pc - GETARG_Bx(i) + 2 - 1 < pc);
-      loc_pc = pc;
+      loc_pc = pc - GETARG_Bx(i) + 2 - 1;
     } else {
       continue;
     }


### PR DESCRIPTION
With the slight rejig in the Lua VM, this is as likely (or as unlikely!) to form a loop as putting things at `FORLOOP`, but means we don't have to go through one iteration of the interpreter to get to the jump to machine code.