### PR TITLE
Add yklocations to recursive-via-tail-call functions.

### DIFF
--- a/src/ldo.c
+++ b/src/ldo.c
@@ -713,7 +713,16 @@ int luaD_pretailcall (lua_State *L, CallInfo *ci, StkId func,
 #if YKLUA_DEBUG_STRS
           yk_location_set_debug_str(&p->yklocs[0], p->instdebugstrs[0]);
 #endif
+        } else if (!p->called) {
+          p->called = true;
         }
+        // Because this is a tail call the "current" function -- `caller_p` --
+        // has implicitly returned. If the "current" function is the same as
+        // the "about to call" function, we don't do anything; in all other
+        // cases we mark the "current" function as uncalled.
+        Proto *caller_p = ci_func(ci)->p;
+        if (caller_p != p)
+          caller_p->called = false;
       }
 #endif
       ci->u.l.savedpc = p->code;  /* starting point */


### PR DESCRIPTION
Before this commit, tail calls bypassed our "spot recursive functions and add a `YkLocation` to them" check. The `p->called` in this commit fixes that problem _but_ we then need to account for the fact that this means the caller function has implicitly returned: if it _isn't_ the current function we need to mark it as uncalled.

As before, this heuristic isn't perfect, but it solves an obvious limitation in yklua, though it doesn't make much difference to actual benchmarks.