### PR TITLE
Remove `proto_version`.

### DIFF
--- a/src/lfunc.c
+++ b/src/lfunc.c
@@ -25,10 +25,6 @@
 #include "lobject.h"
 #include "lstate.h"
 
-#ifdef USE_YK
-uint64_t global_proto_version = 0;
-#endif
-
 
 CClosure *luaF_newCclosure (lua_State *L, int nupvals) {
   GCObject *o = luaC_newobj(L, LUA_VCCL, sizeCclosure(nupvals));
@@ -277,7 +273,6 @@ Proto *luaF_newproto (lua_State *L) {
   f->instdebugstrs = NULL;
 #endif
   f->sizeyklocs = 0;
-  f->proto_version = global_proto_version;
 #endif
   return f;
 }
@@ -299,9 +294,6 @@ lu_mem luaF_protosize (Proto *p) {
 
 
 void luaF_freeproto (lua_State *L, Proto *f) {
-#ifdef USE_YK
-  global_proto_version++;
-#endif
   if (!(f->flag & PF_FIXED)) {
     luaM_freearray(L, f->code, cast_sizet(f->sizecode));
     luaM_freearray(L, f->lineinfo, cast_sizet(f->sizelineinfo));

--- a/src/lfunc.h
+++ b/src/lfunc.h
@@ -10,14 +10,6 @@
 
 #include "lobject.h"
 
-#ifdef USE_YK
-// Every time a function is deleted, we crank this integer. Thus if two
-// `Proto`s are allocated -- at different times! -- at the same address, the
-// idempotent `load_inst` function won't consider them to be the same function.
-extern uint64_t global_proto_version;
-#endif
-
-
 #define sizeCclosure(n)  \
 	(offsetof(CClosure, upvalue) + sizeof(TValue) * cast_uint(n))
 

--- a/src/lobject.h
+++ b/src/lobject.h
@@ -631,7 +631,6 @@ typedef struct Proto {
   char **instdebugstrs; /* One `char *` per instruction in `code` */
 #endif
   int sizeyklocs; /* size of 'yklocs' and (if present) `instDebugStr` */
-  uint64_t proto_version; /* What 'Proto Version' was this created under? */
 #endif
   struct Proto **p;  /* functions defined inside the function */
   Upvaldesc *upvalues;  /* upvalue information */

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -1256,8 +1256,8 @@ lua_Integer load_int(const TValue *o) {
 #ifdef USE_YK
 // Elide instruction lookup.
 __attribute__((yk_idempotent))
-Instruction load_inst(uint64_t pv, const Instruction *pc) {
-  NOOPT_VAL(pv);
+Instruction load_inst(const Instruction *pc) {
+  NOOPT_VAL(pc);
   return *pc;
 }
 
@@ -1270,8 +1270,7 @@ Instruction load_inst(uint64_t pv, const Instruction *pc) {
     i = *pc; \
   } else { \
     pc = (Instruction *) yk_promote((void *) pc); \
-    uint64_t pv = yk_promote(cl_proto_version); \
-    i = load_inst(pv, pc); \
+    i = load_inst(pc); \
   } \
   pc++; \
 }
@@ -1303,9 +1302,6 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
   trap = L->hookmask;
  returning:  /* trap already set */
   cl = ci_func(ci);
-#ifdef USE_YK
-  uint64_t cl_proto_version = cl->p->proto_version;
-#endif
   k = cl->p->k;
   pc = ci->u.l.savedpc;
   if (l_unlikely(trap))


### PR DESCRIPTION
This dates from a time when we were seeing random crashes in yklua and I reached for this as a hack: the crashes went away, but I think that was not because `proto_version` was the right fix. Indeed, I'm now fairly confident that `proto_version` is by unnecessary: by definition, if we create a new `Proto` we get a new `YkLocation` so `proto_version` can't do anything. This does lead to a small speedup across several Lua benchmarks.