### PR TITLE
Unroll `genmoveresults`.

### DIFF
--- a/src/ldo.c
+++ b/src/ldo.c
@@ -545,6 +545,9 @@ static unsigned tryfuncTM (lua_State *L, StkId func, unsigned status) {
 
 
 /* Generic case for 'moveresult' */
+#ifdef USE_YK
+__attribute__((yk_unroll))
+#endif
 l_sinline void genmoveresults (lua_State *L, StkId res, int nres,
                                              int wanted) {
   StkId firstresult = L->top.p - nres;  /* index of first result */


### PR DESCRIPTION
This speeds up LuLpeg quite a bit, and has a very tiny negative impact on hashids. Overall, it seems worth it.