### PR TITLE
Inline `setnodevector(..., 0)`.

### DIFF
--- a/src/ltable.c
+++ b/src/ltable.c
@@ -803,7 +803,15 @@ Table *luaH_new (lua_State *L) {
   t->flags = maskflags;  /* table has no metamethod fields */
   t->array = NULL;
   t->asize = 0;
+#ifdef USE_YK
+  // We don't want to make `setnodevector` "unroll" because the non-zero case
+  // may not be constant.
+  t->node = cast(Node *, dummynode);  /* use common 'dummynode' */
+  t->lsizenode = 0;
+  setdummy(t);  /* signal that it is using dummy node */
+#else
   setnodevector(L, t, 0);
+#endif
   return t;
 }
 


### PR DESCRIPTION
`setnodevector` is really two functions: a general purpose function that can be called with an arbitrary number of run-time values; and a special, fast, case for zero, which is called a lot, mostly in `luaH_new`. The easiest way to inline this into a trace is to manually inline it! This speeds up Fannkuch and Mandlebrot, without any obvious ill effects on anything else.